### PR TITLE
Disable plugin on fika dedicated

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -6,6 +6,7 @@ using MoxoPixel.MenuOverhaul.Utils;
 namespace MoxoPixel.MenuOverhaul
 {
     [BepInPlugin("moxo.pixel.menuoverhaul", "MoxoPixel-MenuOverhaul", "1.0.3")]
+    [BepInDependency("com.fika.dedicated", BepInDependency.DependencyFlags.SoftDependency)] 
     public class Plugin : BaseUnityPlugin
     {
         public static ManualLogSource LogSource;
@@ -13,6 +14,12 @@ namespace MoxoPixel.MenuOverhaul
         private void Awake()
         {
             LogSource = Logger;
+            fikaDedicatedDetected = Chainloader.PluginInfos.Keys.Contains("com.fika.dedicated");
+            if (fikaDedicatedDetected) {
+                LogSource.LogInfo("MenuOverhaul by MoxoPixel not loaded, FIKA Dedicated plugin detected");
+                return;
+            }
+            
             Settings.Init(Config);
 
             new MenuOverhaulPatch().Enable();


### PR DESCRIPTION
This plugin just errors on FIKA Dedicated clients as they never load the menu. So this should check if that plugin exists and not run if it does. 